### PR TITLE
Linux build & Tracy on demand

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,17 +76,21 @@ tasks.register("extractGLFW", Sync) {
 
 def targets = [
     // Linux
-    "aarch64-linux-musl",
-    "x86_64-linux-musl",
-    "riscv64-linux-musl",
+    "aarch64-linux-gnu",
+    "x86_64-linux-gnu",
     // Windows
     "x86_64-windows-gnu",
     "aarch64-windows-gnu",
     "x86-windows-gnu",
-    // MacOS
-    "x86_64-macos",
-    "aarch64-macos"
 ]
+
+if (System.properties['os.name'].toLowerCase().contains('mac')) {
+    targets += [
+        // MacOS
+        "x86_64-macos",
+        "aarch64-macos"
+    ]
+}
 
 def buildAll = tasks.register("buildAll")
 
@@ -104,7 +108,7 @@ targets.forEach { target ->
 
         workingDir projectDir
         def buildTarget = target == "aarch64-macos" ? "native" : target
-        commandLine "/opt/homebrew/bin/zig", "build", "-Doptimize=ReleaseSmall", "-Dtarget=${buildTarget}", "--prefix", outputDir
+        commandLine "zig", "build", "-Doptimize=ReleaseSmall", "-Dtarget=${buildTarget}", "--prefix", outputDir
     }
     buildAll.configure {
         dependsOn buildTask

--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ const tracy = "build/tracy/tracy-0.11.1/";
 fn buildJtracy(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) void {
     const lib = b.addSharedLibrary(.{ .name = "jtracy", .target = target, .optimize = optimize });
 
-    const base_args = &[_][]const u8{ "--std=c++20", "-DTRACY_ENABLE" };
+    const base_args = &[_][]const u8{ "--std=c++20", "-DTRACY_ENABLE", "-DTRACY_NO_CRASH_HANDLER" };
     const args = if (target.result.os.tag == .windows)
         base_args ++ &[_][]const u8{
             "-DJNIEXPORT=__declspec(dllexport)",
@@ -16,6 +16,7 @@ fn buildJtracy(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.bu
     const env = std.process.getEnvMap(b.allocator) catch unreachable;
     const java_home = env.get("JAVA_HOME") orelse unreachable;
     const java_include_path = std.fmt.allocPrint(b.allocator, "{s}/include", .{java_home}) catch unreachable;
+    const java_linux_include_path = std.fmt.allocPrint(b.allocator, "{s}/include/linux", .{java_home}) catch unreachable;
     const java_darwin_include_path = std.fmt.allocPrint(b.allocator, "{s}/include/darwin", .{java_home}) catch unreachable;
 
     lib.addCSourceFiles(.{
@@ -24,6 +25,7 @@ fn buildJtracy(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.bu
     });
     lib.addIncludePath(b.path(tracy ++ "public"));
     lib.addSystemIncludePath(.{ .cwd_relative = java_include_path });
+    lib.addSystemIncludePath(.{ .cwd_relative = java_linux_include_path });
     lib.addSystemIncludePath(.{ .cwd_relative = java_darwin_include_path });
 
     lib.linkLibC();

--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ const tracy = "build/tracy/tracy-0.11.1/";
 fn buildJtracy(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode) void {
     const lib = b.addSharedLibrary(.{ .name = "jtracy", .target = target, .optimize = optimize });
 
-    const base_args = &[_][]const u8{ "--std=c++20", "-DTRACY_ENABLE", "-DTRACY_NO_CRASH_HANDLER" };
+    const base_args = &[_][]const u8{ "--std=c++20", "-DTRACY_ENABLE", "-DTRACY_NO_CRASH_HANDLER", "-DTRACY_ON_DEMAND" };
     const args = if (target.result.os.tag == .windows)
         base_args ++ &[_][]const u8{
             "-DJNIEXPORT=__declspec(dllexport)",

--- a/src/main/cpp/JTracy.cpp
+++ b/src/main/cpp/JTracy.cpp
@@ -152,3 +152,8 @@ extern "C" JNIEXPORT void JNICALL Java_com_mojang_jtracy_TracyBindings_messageCo
   TracyCMessageC(chars, length, static_cast<uint32_t>(color));
   env->ReleaseStringUTFChars(text, chars);
 }
+
+extern "C" JNIEXPORT jboolean JNICALL Java_me_modmuss50_tracyutils_TracyBindingsExtension_isConnected(
+    JNIEnv *, jclass) {
+  return static_cast<jboolean>(TracyCIsConnected != 0);
+}

--- a/src/main/java/me/modmuss50/tracyutils/TracyBindingsExtension.java
+++ b/src/main/java/me/modmuss50/tracyutils/TracyBindingsExtension.java
@@ -1,0 +1,9 @@
+package me.modmuss50.tracyutils;
+
+class TracyBindingsExtension {
+    private TracyBindingsExtension() {
+    }
+
+    public static native boolean isConnected();
+
+}

--- a/src/main/java/me/modmuss50/tracyutils/TracyClientExtension.java
+++ b/src/main/java/me/modmuss50/tracyutils/TracyClientExtension.java
@@ -3,12 +3,11 @@ package me.modmuss50.tracyutils;
 import me.modmuss50.tracyutils.mixin.TracyClientAccessor;
 
 public class TracyClientExtension {
-
     public static boolean isConnected(){
-        if (!TracyClientAccessor.isLoaded()) {
+        if (TracyClientAccessor.isLoaded()) {
             return TracyBindingsExtension.isConnected();
         } else {
             return false;
         }
-    };
+    }
 }

--- a/src/main/java/me/modmuss50/tracyutils/TracyClientExtension.java
+++ b/src/main/java/me/modmuss50/tracyutils/TracyClientExtension.java
@@ -1,0 +1,14 @@
+package me.modmuss50.tracyutils;
+
+import me.modmuss50.tracyutils.mixin.TracyClientAccessor;
+
+public class TracyClientExtension {
+
+    public static boolean isConnected(){
+        if (!TracyClientAccessor.isLoaded()) {
+            return TracyBindingsExtension.isConnected();
+        } else {
+            return false;
+        }
+    };
+}

--- a/src/main/java/me/modmuss50/tracyutils/client/TracyUtilsClient.java
+++ b/src/main/java/me/modmuss50/tracyutils/client/TracyUtilsClient.java
@@ -3,6 +3,7 @@ package me.modmuss50.tracyutils.client;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import me.modmuss50.tracyutils.NativeLocator;
+import me.modmuss50.tracyutils.TracyClientExtension;
 import me.modmuss50.tracyutils.mixin.TracyClientAccessor;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandManager;
@@ -24,6 +25,7 @@ public class TracyUtilsClient implements ClientModInitializer {
                 ClientCommandManager.literal("tracyclient")
                         .then(ClientCommandManager.literal("start").executes(TracyUtilsClient::executeStart))
                         .then(ClientCommandManager.literal("stop").executes(TracyUtilsClient::executeStop))
+                        .then(ClientCommandManager.literal("isConnected").executes(TracyUtilsClient::isConnected))
         ));
     }
 
@@ -58,6 +60,18 @@ public class TracyUtilsClient implements ClientModInitializer {
 
         return 0;
     }
+
+    private static int isConnected(CommandContext<FabricClientCommandSource> ctx) throws CommandSyntaxException {
+        if (!TracyClientAccessor.isLoaded()) {
+            ctx.getSource().sendError(Text.literal("Tracy is not running"));
+            return 1;
+        }
+
+        ctx.getSource().sendFeedback(Text.literal("Tracy server connected: " + TracyClientExtension.isConnected()));
+
+        return 0;
+    }
+
 
     private static boolean runProfilerUI() throws IOException {
         Optional<Path> executable = NativeLocator.getTracyProfiler();

--- a/src/main/java/me/modmuss50/tracyutils/mixin/TracyClientMixin.java
+++ b/src/main/java/me/modmuss50/tracyutils/mixin/TracyClientMixin.java
@@ -1,8 +1,10 @@
 package me.modmuss50.tracyutils.mixin;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.mojang.jtracy.TracyClient;
+import me.modmuss50.tracyutils.TracyClientExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongepowered.asm.mixin.Mixin;
@@ -19,6 +21,12 @@ public class TracyClientMixin {
 
     @Unique
     private static boolean loadedNatives = false;
+
+    @ModifyExpressionValue(method = "beginZone*", at = @At(value = "FIELD", target = "Lcom/mojang/jtracy/TracyClient;loaded:Z"))
+    private static boolean beginZone(boolean original){
+        // don't begin Zone if not connected to server, to prevent ending zones that were started before connection
+        return (original && TracyClientExtension.isConnected());
+    }
 
     @WrapOperation(method = "load", at = @At(value = "INVOKE", target = "Lcom/mojang/jtracy/Loader;load()V"))
     private static void load(@Coerce Object instance, Operation<Void> original) {


### PR DESCRIPTION
_I'm lazy to make 2 separate PRs for this, can still do this if the second part is controversial, you can also review each commit separately_

### Linux build:
- Updates the build scripts so that the linux build is using gnu libc instead of musl. Not sure if there is a use-case for specific musl builds. If there is, then we'd need build both to find a way to determine the correct library at runtime.
- Removed `riscv64-linux`. I can't get this to build with gnu. Maybe that can be looked at again.
- Don't build macos builds on non mac machines.
- unhardcode zig path, should be on PATH.
- add java linux include path.
- compile with `-DTRACY_NO_CRASH_HANDLER` to avoid crash due to java using `SIGPWR` internally.

### Tracy on demand:
- compile with `-DTRACY_ON_DEMAND` to allow multiple profiling sessions without restarting the game.
- only start zones if connected, since otherwise we get an error that zones are closed without being opened
   - to allow this, added a `isConnected()` method to the tracy binding
   - also added the `/tracyclient isConnected` subcommend to verify the connection

**Possible issue:** Profiling only starts when a server is connected, so it's more difficult to profile the game-start with this. It might make sense to add an option to wait for a connection at startup. 